### PR TITLE
Fix ordering in tests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -39,6 +39,7 @@
     "linebreak-style": 0,
     "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],
     "jsx-a11y/no-autofocus": 0,
-    "jsx-a11y/href-no-hash": 0
+    "jsx-a11y/href-no-hash": 0,
+    "jsx-a11y/label-has-for": 0
   }
 }

--- a/server/graphql/queries/entries/multiple.js
+++ b/server/graphql/queries/entries/multiple.js
@@ -37,6 +37,7 @@ module.exports = {
 
     return Entry
       .find(fargs)
+      .sort({ dateCreated: 1 })
       .populate('author')
       .select(projection)
       .exec();

--- a/server/graphql/queries/pages/multiple.js
+++ b/server/graphql/queries/pages/multiple.js
@@ -17,6 +17,7 @@ module.exports = {
 
     return Page
       .find()
+      .sort({ dateCreated: 1 })
       .select(projection)
       .exec();
   },

--- a/server/graphql/queries/usergroups/multiple.js
+++ b/server/graphql/queries/usergroups/multiple.js
@@ -23,6 +23,7 @@ module.exports = {
 
     return UserGroup
       .find(args)
+      .sort({ dateCreated: 1 })
       .select(projection)
       .exec();
   },

--- a/server/graphql/queries/users/multiple.js
+++ b/server/graphql/queries/users/multiple.js
@@ -17,6 +17,7 @@ module.exports = {
 
     return User
       .find()
+      .sort({ dateCreated: 1 })
       .populate('usergroup')
       .select(projection)
       .lean()


### PR DESCRIPTION
Makes tests a little more reliable by adding sort (by `dateCreated` in the `multiple.js` mongo queries.