### PR TITLE
Cache busting

### DIFF
--- a/dev.js
+++ b/dev.js
@@ -1,5 +1,7 @@
 const Flint = require('.');
 
-const flintServer = new Flint({}, true);
+const flintServer = new Flint({
+  enableCacheBusting: true,
+}, true);
 
 flintServer.startServer();

--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ module.exports = class Flint {
    * @property {String} [siteName] - The title of your site
    * @property {String} [siteUrl] - The URL to your site
    * @property {Boolean} [listen] - Should the server listen; used for testing
+   * @property {Boolean} [enableCacheBusting] - Add a hash to the compiled CSS bundle
    * @property {Function[]} [plugins] - Array of required Class modules
    *
    * @param {Flint} settings

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "async/await"
   ],
   "scripts": {
-    "start": "cross-env DEBUG=flint nodemon --ignore app dev.js",
+    "start": "cross-env DEBUG=flint* nodemon --ignore app dev.js",
     "test": "cross-env NODE_ENV=test mocha",
     "test:coverage": "nyc npm test && nyc report --reporter=text-lcov | coveralls",
     "test:api": "npm test -- --grep \"GraphQL API\"",

--- a/server/graphql/types/Site.js
+++ b/server/graphql/types/Site.js
@@ -26,6 +26,15 @@ const fields = {
     type: GraphQLBoolean,
     description: 'Boolean to allow or disallow the public registration routes.',
   },
+  enableCacheBusting: {
+    type: GraphQLBoolean,
+    description: 'Enable or disable hash generation for the CSS bundle.',
+    defaultValue: false,
+  },
+  cacheHash: {
+    type: GraphQLString,
+    description: 'The hash used to cache bust for the CSS bundle.',
+  },
 };
 
 exports.outputType = new GraphQLObjectType({

--- a/server/graphql/types/Site.js
+++ b/server/graphql/types/Site.js
@@ -31,7 +31,7 @@ const fields = {
     description: 'Enable or disable hash generation for the CSS bundle.',
     defaultValue: false,
   },
-  cacheHash: {
+  cssHash: {
     type: GraphQLString,
     description: 'The hash used to cache bust for the CSS bundle.',
   },

--- a/server/models/SiteModel.js
+++ b/server/models/SiteModel.js
@@ -32,6 +32,11 @@ const SiteSchema = new Schema({
     type: String,
     default: 'main.scss',
   },
+  enableCacheBusting: {
+    type: Boolean,
+    default: false,
+  },
+  cacheHash: String,
 }, { strict: false });
 
 SiteSchema.name = 'Site';

--- a/server/models/SiteModel.js
+++ b/server/models/SiteModel.js
@@ -36,7 +36,7 @@ const SiteSchema = new Schema({
     type: Boolean,
     default: false,
   },
-  cacheHash: String,
+  cssHash: String,
 }, { strict: false });
 
 SiteSchema.name = 'Site';

--- a/server/utils/collectData.js
+++ b/server/utils/collectData.js
@@ -158,6 +158,8 @@ async function collectData(entry) {
       siteName
       siteUrl
       style
+      enableCacheBusting
+      cacheHash
     }
   }`;
 

--- a/server/utils/collectData.js
+++ b/server/utils/collectData.js
@@ -159,7 +159,7 @@ async function collectData(entry) {
       siteUrl
       style
       enableCacheBusting
-      cacheHash
+      cssHash
     }
   }`;
 

--- a/server/utils/compileSass.js
+++ b/server/utils/compileSass.js
@@ -13,6 +13,7 @@ const writeFileAsync = promisify(fs.writeFile);
 function sassAsync(opt) {
   return new Promise((resolve, reject) => {
     sass.render(opt, (err, res) => {
+      /* istanbul ignore if */
       if (err) reject(err);
       resolve(res);
     });
@@ -64,7 +65,7 @@ async function compile() {
 
     await writeFileAsync(pathToFile, scss.css);
     return `${chalk.grey('[SCSS]')} Your SCSS has been compiled to ${pathToFile}`;
-  } catch (e) {
+  } catch (e) /* istanbul ignore next */ {
     log(`  ${chalk.grey('Message:')} ${chalk.red(e.message)}`);
     log(`  ${chalk.grey('Line:')} ${chalk.red(e.line)}`);
     log(`  ${chalk.grey('File:')} ${chalk.red(e.file)}`);
@@ -73,12 +74,14 @@ async function compile() {
   }
 }
 
+/* istanbul ignore next */
 function recompile() {
   // eslint-disable-next-line no-console
   log(chalk.cyan('Recompiling SASS...'));
   return compile();
 }
 
+/* istanbul ignore next */
 function watch(watcher) {
   watcher.on('add', async () => {
     const compiled = await recompile();
@@ -95,6 +98,7 @@ function watch(watcher) {
  */
 async function compileSass() {
   if (global.FLINT.scssEntryPoint) {
+    /* istanbul ignore if */
     if (global.FLINT.debugMode) {
       const watcher = chokidar.watch(global.FLINT.scssPath, {
         persistent: true,

--- a/server/utils/compileSass.js
+++ b/server/utils/compileSass.js
@@ -36,15 +36,15 @@ async function handleCacheBusting() {
 
   const Site = mongoose.model('Site');
 
-  const cacheHash = generateHash();
-  global.FLINT.cacheHash = cacheHash;
+  const cssHash = generateHash();
+  global.FLINT.cssHash = cssHash;
   const site = await Site.findOne().exec();
-  const updatedSite = await Site.findByIdAndUpdate(site._id, { cacheHash }, { new: true }).exec();
+  const updatedSite = await Site.findByIdAndUpdate(site._id, { cssHash }, { new: true }).exec();
 
   /* istanbul ignore if */
   if (!updatedSite) throw new Error('Could not save the site config to the database.');
 
-  return filename.replace('.css', `-${cacheHash}.css`);
+  return filename.replace('.css', `-${cssHash}.css`);
 }
 
 /**
@@ -52,10 +52,13 @@ async function handleCacheBusting() {
  * @param {object} opts - Compile options
  */
 async function compile() {
+  /* istanbul ignore next */
+  const outputStyle = process.env.NODE_ENV === 'production' ? 'compressed' : 'nested';
+
   const opts = {
     file: path.join(global.FLINT.scssPath, global.FLINT.scssEntryPoint),
-    outputStyle: process.env.NODE_ENV === 'production' ? 'compressed' : 'nested',
     includePaths: global.FLINT.scssIncludePaths,
+    outputStyle,
   };
 
   try {

--- a/server/utils/scaffold.js
+++ b/server/utils/scaffold.js
@@ -5,6 +5,7 @@ const mkdirAsync = promisify(fs.mkdir);
 /**
  * Creates a directory at the given path if it does not already exist.
  * @param {String} path - Path to the directory
+ * @returns {Promise<string>} - Path to the directory
  */
 function scaffold(path) {
   return new Promise((resolve) => {

--- a/test/fixtures/scss/main.css
+++ b/test/fixtures/scss/main.css
@@ -1,0 +1,2 @@
+body {
+  background-color: red; }

--- a/test/fixtures/scss/main.scss
+++ b/test/fixtures/scss/main.scss
@@ -1,0 +1,3 @@
+body {
+    background-color: red;
+}

--- a/test/server/utils/compileSass.js
+++ b/test/server/utils/compileSass.js
@@ -1,0 +1,63 @@
+const Flint = require('../../../index.js');
+const expect = require('chai').expect;
+const mongoose = require('mongoose');
+const fs = require('fs');
+const { promisify } = require('util');
+const path = require('path');
+const compileSass = require('../../../server/utils/compileSass');
+
+const readFile = promisify(fs.readFile);
+const rimraf = promisify(require('rimraf'));
+
+describe('Compile SCSS', function () {
+  before('Setup global variables', function (done) {
+    global.FLINT = {
+      publicPath: path.join(__dirname, '..', '..', 'temp', 'public'),
+      scssEntryPoint: 'main.scss',
+      scssPath: path.join(__dirname, '..', '..', 'fixtures', 'scss'),
+      scssIncludePaths: [],
+    };
+
+    done();
+  });
+
+  it('compiles scss', async function () {
+    const result = await compileSass();
+    expect(result).to.include('Your SCSS has been compiled to');
+
+    const fixture = await readFile(path.join(__dirname, '..', '..', 'fixtures', 'scss', 'main.css'), 'utf-8');
+    const compiled = await readFile(path.join(__dirname, '..', '..', 'temp', 'public', 'main.css'), 'utf-8');
+    expect(compiled).to.equal(fixture);
+  });
+});
+
+describe('Cache busting', function () {
+  before('Create server and delete the temp folder', async function () {
+    await rimraf('test/temp/public');
+    const flintServer = new Flint({
+      scssPath: 'test/fixtures/scss',
+      publicPath: 'test/temp/public',
+      enableCacheBusting: true,
+      listen: false,
+    });
+
+    return flintServer.startServer();
+  });
+
+  it('compiles scss with cache busting', async function () {
+    const result = await compileSass();
+    expect(result).to.include('Your SCSS has been compiled to');
+    expect(result).to.not.include('main.css');
+
+    const Site = mongoose.model('Site');
+    const site = await Site.findOne().exec();
+
+    const fixture = await readFile(path.join(__dirname, '..', '..', 'fixtures', 'scss', 'main.css'), 'utf-8');
+    const compiled = await readFile(path.join(__dirname, '..', '..', 'temp', 'public', `main-${site.cacheHash}.css`), 'utf-8');
+    expect(compiled).to.equal(fixture);
+  });
+
+  after((done) => {
+    mongoose.disconnect(done);
+  });
+});

--- a/test/server/utils/compileSass.js
+++ b/test/server/utils/compileSass.js
@@ -21,6 +21,10 @@ describe('Compile SCSS', function () {
     done();
   });
 
+  afterEach('Delete the temp public folder', function () {
+    return rimraf('test/temp/public');
+  });
+
   it('compiles scss', async function () {
     const result = await compileSass();
     expect(result).to.include('Your SCSS has been compiled to');
@@ -29,11 +33,24 @@ describe('Compile SCSS', function () {
     const compiled = await readFile(path.join(__dirname, '..', '..', 'temp', 'public', 'main.css'), 'utf-8');
     expect(compiled).to.equal(fixture);
   });
+
+  describe('Disable SCSS compiling', function () {
+    before('Setup global variables', function (done) {
+      global.FLINT.scssEntryPoint = false;
+      done();
+    });
+
+    it('does not compile scss', async function () {
+      const result = await compileSass();
+      expect(result).to.include('SCSS compiling has been disabled in the site configuration.');
+      const pathToMainCSS = path.join(__dirname, '..', '..', 'temp', 'public', 'main.css');
+      return expect(fs.existsSync(pathToMainCSS)).to.be.false;
+    });
+  });
 });
 
 describe('Cache busting', function () {
   before('Create server and delete the temp folder', async function () {
-    await rimraf('test/temp/public');
     const flintServer = new Flint({
       scssPath: 'test/fixtures/scss',
       publicPath: 'test/temp/public',

--- a/test/server/utils/compileSass.js
+++ b/test/server/utils/compileSass.js
@@ -67,10 +67,10 @@ describe('Cache busting', function () {
     expect(result).to.not.include('main.css');
 
     const Site = mongoose.model('Site');
-    const site = await Site.findOne().exec();
+    const site = await Site.findOne().select('cssHash').exec();
 
     const fixture = await readFile(path.join(__dirname, '..', '..', 'fixtures', 'scss', 'main.css'), 'utf-8');
-    const compiled = await readFile(path.join(__dirname, '..', '..', 'temp', 'public', `main-${site.cacheHash}.css`), 'utf-8');
+    const compiled = await readFile(path.join(__dirname, '..', '..', 'temp', 'public', `main-${site.cssHash}.css`), 'utf-8');
     expect(compiled).to.equal(fixture);
   });
 


### PR DESCRIPTION
Add cache busting for the CSS bundle by creating a hash and adding it the file path. It also stores the newly generated hash in the DB's Site object, and deletes the old file if it exists.

Closes #48 