### PR TITLE
Fix updatePage

### DIFF
--- a/server/graphql/mutations/pages/updatePage.js
+++ b/server/graphql/mutations/pages/updatePage.js
@@ -20,7 +20,9 @@ module.exports = {
     if (!perms.pages.canEditPages) throw new Error('You do not have permission to edit Pages.');
     const foundPage = await Page.findById(_id).exec();
     if (!foundPage) throw new Error('There is no Page with this ID');
-    if (!(foundPage.homepage || data.homepage) && data.route.startsWith('/admin')) throw new Error('Routes starting with `/admin` are reserved for Flint.');
+    if (!(foundPage.homepage || data.homepage) && (data.route || foundPage.route).startsWith('/admin')) {
+      throw new Error('Routes starting with `/admin` are reserved for Flint.');
+    }
 
     events.emit('pre-update-page', { _id, data });
 


### PR DESCRIPTION
There is currently a bug in the `updatePage` mutation where if the `data` object does not explicitly include a route string (which it won't if the update is made from the page content view), it throws a `cannot read property startsWith of undefined`.