### PR TITLE
Change logger to Bunyan

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,19 +116,14 @@ module.exports = class Flint {
       logger.error(e)
     }
 
-    try {
-      const canCompileSass = await compileSass(logger)
-      logger.info(canCompileSass)
-    } catch (e) {
-      logger.error(e)
-    }
+    await compileSass(logger)
 
     this.server = createServer(logger)
 
     if (global.FLINT.listen !== false) {
       this.server.listen(port, () => {
         // eslint-disable-next-line no-console
-        logger.info(`[HTTP Server] Flint server running at http://localhost:${port}\n`)
+        logger.info(`[HTTP Server] Flint server running at http://localhost:${port}`)
       })
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1848,6 +1848,17 @@
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
     },
+    "bunyan": {
+      "version": "1.8.12",
+      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.12.tgz",
+      "integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
+      "requires": {
+        "dtrace-provider": "0.8.6",
+        "moment": "2.18.1",
+        "mv": "2.1.1",
+        "safe-json-stringify": "1.2.0"
+      }
+    },
     "busboy": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.14.tgz",
@@ -4078,6 +4089,15 @@
       "resolved": "https://registry.npmjs.org/draft-js-utils/-/draft-js-utils-1.1.0.tgz",
       "integrity": "sha1-ZSh2q91JEKeZax/bZMjXceQ5f3U=",
       "dev": true
+    },
+    "dtrace-provider": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.6.tgz",
+      "integrity": "sha1-QooiOv4DQl0s1tY0f99AxmkDVj0=",
+      "optional": true,
+      "requires": {
+        "nan": "2.7.0"
+      }
     },
     "duplexer": {
       "version": "0.1.1",
@@ -10224,6 +10244,41 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
     },
+    "mv": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+      "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
+      "optional": true,
+      "requires": {
+        "mkdirp": "0.5.1",
+        "ncp": "2.0.0",
+        "rimraf": "2.4.5"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "optional": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.4.5",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+          "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
+          "optional": true,
+          "requires": {
+            "glob": "6.0.4"
+          }
+        }
+      }
+    },
     "nan": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
@@ -10242,6 +10297,12 @@
       "requires": {
         "xml-char-classes": "1.0.0"
       }
+    },
+    "ncp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
+      "optional": true
     },
     "negotiator": {
       "version": "0.6.1",
@@ -15878,6 +15939,12 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "safe-json-stringify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
+      "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
+      "optional": true
     },
     "sane": {
       "version": "2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -204,6 +204,16 @@
         "color-convert": "1.9.0"
       }
     },
+    "ansicolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
+      "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8="
+    },
+    "ansistyles": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
+      "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk="
+    },
     "anymatch": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
@@ -1857,6 +1867,31 @@
         "moment": "2.18.1",
         "mv": "2.1.1",
         "safe-json-stringify": "1.2.0"
+      }
+    },
+    "bunyan-format": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/bunyan-format/-/bunyan-format-0.2.1.tgz",
+      "integrity": "sha1-pLOw2ABwqGUnlBcmnj8A/wL7y0c=",
+      "requires": {
+        "ansicolors": "0.2.1",
+        "ansistyles": "0.1.3",
+        "xtend": "2.1.2"
+      },
+      "dependencies": {
+        "object-keys": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
+        },
+        "xtend": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+          "requires": {
+            "object-keys": "0.4.0"
+          }
+        }
       }
     },
     "busboy": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "bcrypt-nodejs": "^0.0.3",
     "body-parser": "^1.18.2",
     "bunyan": "^1.8.12",
+    "bunyan-format": "^0.2.1",
     "camelcase": "^4.0.0",
     "chalk": "^2.1.0",
     "cheerio": "^0.22.0",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
   "dependencies": {
     "bcrypt-nodejs": "^0.0.3",
     "body-parser": "^1.18.2",
+    "bunyan": "^1.8.12",
     "camelcase": "^4.0.0",
     "chalk": "^2.1.0",
     "cheerio": "^0.22.0",

--- a/server/apps/admin.js
+++ b/server/apps/admin.js
@@ -2,13 +2,11 @@
 
 const express = require('express')
 const path = require('path')
-const chalk = require('chalk')
 const webpack = require('webpack')
 const webpackMiddleware = require('webpack-dev-middleware')
 const webpackHotMiddleware = require('webpack-hot-middleware')
-const log = require('debug')('flint')
 
-module.exports = (app) => {
+module.exports = (app, log) => {
   const admin = express()
 
   admin.use(require('./routes/auth')())
@@ -38,7 +36,7 @@ module.exports = (app) => {
       res.end()
     })
 
-    log(`${chalk.cyan('[App: Admin]')} initialized in Dev mode.`)
+    log.info('[App: Admin] initialized in Dev mode.')
   } else {
     const STATIC_PATH = path.join(__dirname, '..', '..', 'admin')
 
@@ -51,7 +49,7 @@ module.exports = (app) => {
       res.sendFile(path.join(__dirname, '..', '..', 'admin', 'index.html'))
     })
 
-    log(`${chalk.gray('[App: Admin]')} initialized.`)
+    log.info('[App: Admin] initialized.')
   }
 
   return admin

--- a/server/apps/admin.js
+++ b/server/apps/admin.js
@@ -10,7 +10,7 @@ module.exports = (app, log) => {
   const admin = express()
 
   admin.use(require('./routes/auth')())
-  admin.use('/api', require('./api')(app))
+  admin.use('/api', require('./api')(app, log))
 
   /* istanbul ignore if */
   if (process.env.BUILD_DASHBOARD) {

--- a/server/apps/api.js
+++ b/server/apps/api.js
@@ -1,7 +1,6 @@
 /* eslint-disable global-require */
 
 const express = require('express')
-const chalk = require('chalk')
 
 module.exports = (app, log) => {
   const api = express()
@@ -10,6 +9,6 @@ module.exports = (app, log) => {
   api.use(require('./routes/site')(log))
   api.use(require('./routes/logs')(log))
 
-  log(`${chalk.gray('[App: API]')} initialized.`)
+  log.info('[App: API] initialized.')
   return api
 }

--- a/server/apps/api.js
+++ b/server/apps/api.js
@@ -2,14 +2,13 @@
 
 const express = require('express')
 const chalk = require('chalk')
-const log = require('debug')('flint')
 
-module.exports = (app) => {
+module.exports = (app, log) => {
   const api = express()
 
-  api.use(require('./routes/assets')(app))
-  api.use(require('./routes/site')())
-  api.use(require('./routes/logs')())
+  api.use(require('./routes/assets')(app, log))
+  api.use(require('./routes/site')(log))
+  api.use(require('./routes/logs')(log))
 
   log(`${chalk.gray('[App: API]')} initialized.`)
   return api

--- a/server/apps/graphql.js
+++ b/server/apps/graphql.js
@@ -1,15 +1,13 @@
 const graphqlHTTP = require('express-graphql')
 const h = require('../utils/helpers')
 const express = require('express')
-const chalk = require('chalk')
 const schema = require('../graphql')
 const getUserPermissions = require('../utils/get-user-permissions')
 const emitSocketEvent = require('../utils/emit-socket-event')
 const events = require('../utils/events')
 const log = require('../utils/log')
-const debug = require('debug')('flint')
 
-module.exports = (app) => {
+module.exports = (app, logger) => {
   const graphql = express()
   const io = app.get('io')
 
@@ -29,7 +27,7 @@ module.exports = (app) => {
     }
   })))
 
-  debug(`${chalk.gray('[App: GraphQL]')} initialized.`)
+  logger.info('[App: GraphQL] initialized.')
 
   return graphql
 }

--- a/server/index.js
+++ b/server/index.js
@@ -13,7 +13,7 @@ const { Server } = require('http')
 const io = require('socket.io')
 const shutter = require('http-shutdown')
 
-module.exports = () => {
+module.exports = (log) => {
   require('./utils/passport')(passport)
 
   const app = express()
@@ -50,9 +50,9 @@ module.exports = () => {
 
   app.use(global.FLINT.publicUrl, express.static(global.FLINT.publicPath))
   // app.use('/manifest.json', express.static(path.join(__dirname, '..', 'manifest.json')));
-  app.use('/admin', require('./apps/admin')(app))
-  app.use('/graphql', require('./apps/graphql')(app))
-  app.use(require('./utils/public-registration')())
+  app.use('/admin', require('./apps/admin')(app, log))
+  app.use('/graphql', require('./apps/graphql')(app, log))
+  app.use(require('./utils/public-registration')(log))
 
   // ===== Template Routes
 

--- a/server/utils/FlintPlugin.js
+++ b/server/utils/FlintPlugin.js
@@ -8,12 +8,11 @@ const logger = require('./logger')
  */
 class FlintPlugin {
   constructor (schema) {
-    this.logger = logger
     this.init(schema, events)
   }
 
   static get uid () {
-    this.logger.error('A plugin forgot to set a static getter for the uid. See https://flintcms.co/docs/plugins for more information.')
+    logger.error('A plugin forgot to set a static getter for the uid. See https://flintcms.co/docs/plugins for more information.')
     return false
   }
 
@@ -33,8 +32,8 @@ class FlintPlugin {
   static get model () { return {} }
 
   init () {
-    this.logger.error(`Welcome to the ${this.name} plugin! You have forgotten to create your init class method. Oh well :(`)
-    this.logger.error('The init method of your plugin is the entry point for Flint to know how to deal with the plugin, set up hooks and generally deal with the plugin.')
+    logger.error(`Welcome to the ${this.name} plugin! You have forgotten to create your init class method. Oh well :(`)
+    logger.error('The init method of your plugin is the entry point for Flint to know how to deal with the plugin, set up hooks and generally deal with the plugin.')
   }
 }
 

--- a/server/utils/FlintPlugin.js
+++ b/server/utils/FlintPlugin.js
@@ -1,5 +1,6 @@
 const events = require('./events')
 const path = require('path')
+const logger = require('./logger')
 
 /**
  * Flint Plugin Class
@@ -7,12 +8,12 @@ const path = require('path')
  */
 class FlintPlugin {
   constructor (schema) {
+    this.logger = logger
     this.init(schema, events)
   }
 
   static get uid () {
-    // eslint-disable-next-line no-console
-    console.error('A plugin forgot to set a static getter for the uid. See https://flintcms.co/docs/plugins for more information.')
+    this.logger.error('A plugin forgot to set a static getter for the uid. See https://flintcms.co/docs/plugins for more information.')
     return false
   }
 
@@ -32,8 +33,8 @@ class FlintPlugin {
   static get model () { return {} }
 
   init () {
-    console.error(`Welcome to the ${this.name} plugin! You have forgotten to create your init class method. Oh well :(`)
-    console.error('The init method of your plugin is the entry point for Flint to know how to deal with the plugin, set up hooks and generally deal with the plugin.')
+    this.logger.error(`Welcome to the ${this.name} plugin! You have forgotten to create your init class method. Oh well :(`)
+    this.logger.error('The init method of your plugin is the entry point for Flint to know how to deal with the plugin, set up hooks and generally deal with the plugin.')
   }
 }
 

--- a/server/utils/FlintPlugin.js
+++ b/server/utils/FlintPlugin.js
@@ -1,7 +1,5 @@
 const events = require('./events')
 const path = require('path')
-const chalk = require('chalk')
-const log = require('debug')('flint:plugin')
 
 /**
  * Flint Plugin Class
@@ -14,7 +12,7 @@ class FlintPlugin {
 
   static get uid () {
     // eslint-disable-next-line no-console
-    log(chalk.red('A plugin forgot to set a static getter for the uid. See https://flintcms.co/docs/plugins for more information.'))
+    console.error('A plugin forgot to set a static getter for the uid. See https://flintcms.co/docs/plugins for more information.')
     return false
   }
 
@@ -34,8 +32,8 @@ class FlintPlugin {
   static get model () { return {} }
 
   init () {
-    log(`Welcome to the ${this.name} plugin! You have forgotten to create your init class method. Oh well :(`)
-    log('The init method of your plugin is the entry point for Flint to know how to deal with the plugin, set up hooks and generally deal with the plugin.')
+    console.error(`Welcome to the ${this.name} plugin! You have forgotten to create your init class method. Oh well :(`)
+    console.error('The init method of your plugin is the entry point for Flint to know how to deal with the plugin, set up hooks and generally deal with the plugin.')
   }
 }
 

--- a/server/utils/compile-sass.js
+++ b/server/utils/compile-sass.js
@@ -139,7 +139,7 @@ async function compileSass (log) {
     return compile(log)
   }
 
-  return 'SCSS compiling has been disabled in the site configuration.'
+  log.info('SCSS compiling has been disabled in the site configuration.')
 }
 
 module.exports = compileSass

--- a/server/utils/compile-sass.js
+++ b/server/utils/compile-sass.js
@@ -101,13 +101,12 @@ async function compile (log) {
     log.error(`Line: ${e.line}`)
     log.error(`File: ${e.file}`)
 
-    return `${chalk.red('[SCSS]')} There was an error compiling your SCSS.`
+    return '[SCSS] There was an error compiling your SCSS.'
   }
 }
 
 /* istanbul ignore next */
 function recompile (log) {
-  // eslint-disable-next-line no-console
   log.info('Recompiling SASS...')
   return compile(log)
 }

--- a/server/utils/compile-sass.js
+++ b/server/utils/compile-sass.js
@@ -1,7 +1,6 @@
 const sass = require('node-sass')
 const path = require('path')
 const fs = require('fs')
-const chalk = require('chalk')
 const chokidar = require('chokidar')
 const scaffold = require('./scaffold')
 const { promisify } = require('util')
@@ -95,13 +94,12 @@ async function compile (log) {
       }
     }
 
-    return `${chalk.grey('[SCSS]')} Your SCSS has been compiled to ${pathToFile}`
+    log.info(`[SCSS] Your SCSS has been compiled to ${pathToFile}`)
   } catch (e) /* istanbul ignore next */ {
     log.error(`Message: ${e.message}`)
     log.error(`Line: ${e.line}`)
     log.error(`File: ${e.file}`)
-
-    return '[SCSS] There was an error compiling your SCSS.'
+    log.error('[SCSS] There was an error compiling your SCSS.')
   }
 }
 

--- a/server/utils/database.js
+++ b/server/utils/database.js
@@ -1,8 +1,6 @@
 /* eslint no-console: 0 */
 
 const mongoose = require('mongoose')
-const chalk = require('chalk')
-const log = require('debug')('flint')
 const registerPlugins = require('./register-plugins')
 
 const UserGroupSchema = require('../models/UserGroupSchema')
@@ -17,7 +15,7 @@ const PluginSchema = require('../models/PluginSchema')
 const createAdminUserGroup = require('./create-admin-usergroup')
 const updateSiteConfig = require('./update-site-config')
 
-module.exports = function connectToDatabase () {
+module.exports = function connectToDatabase (log) {
   const config = {
     development: {
       database: 'flint-dev',
@@ -62,10 +60,10 @@ module.exports = function connectToDatabase () {
       mongoose.model('Site', SiteSchema, 'site')
       await updateSiteConfig()
 
-      resolve(`${chalk.green('[Mongoose]')} connection has been successfully established.`)
+      resolve('[Mongoose] connection has been successfully established.')
     })
     mongoose.connection.on('error', e =>
-      reject(new Error(`${chalk.red('[Mongoose]')} Connection error: ${e}`)))
+      reject(new Error(`[Mongoose] Connection error: ${e}`)))
   })
 }
 
@@ -73,7 +71,7 @@ module.exports = function connectToDatabase () {
 /* istanbul ignore next */
 process.on('SIGINT', () => {
   mongoose.connection.close(() => {
-    log('Mongoose default connection disconnected')
+    console.log('Mongoose default connection disconnected')
     process.exit(0)
   })
 })

--- a/server/utils/emails/index.js
+++ b/server/utils/emails/index.js
@@ -1,5 +1,4 @@
 const nodemailer = require('nodemailer')
-const chalk = require('chalk')
 
 const transporter = nodemailer.createTransport({
   host: process.env.MAIL_HOST || 'smtp.gmail.com',
@@ -18,13 +17,13 @@ function verifyNodemailer () {
         switch (error.code) {
           case 'ECONNECTION':
             /* istanbul ignore next */
-            reject(new Error(`${chalk.red('[Email Service]')} Connection could not be established, you may be offline.`))
+            reject(new Error('[Email Service] Connection could not be established, you may be offline.'))
             break
           default:
             reject(error)
         }
       }
-      resolve(`${chalk.grey('[Email Service]')} Server can send emails!`)
+      resolve('[Email Service] Server can send emails!')
     })
   })
 }

--- a/server/utils/generate-env-file.js
+++ b/server/utils/generate-env-file.js
@@ -2,8 +2,6 @@
 
 const fs = require('fs')
 const path = require('path')
-const chalk = require('chalk')
-const log = require('debug')('flint')
 const { promisify } = require('util')
 
 const writeFileAsync = promisify(fs.writeFile)
@@ -44,7 +42,7 @@ MAIL_PASS=
  * @param {String} [cwd=''] - Path to the directory in which the `.env` sits.
  * @returns {Boolean}
  */
-async function generateEnvFile (cwd = '') {
+async function generateEnvFile (cwd = '', log) {
   const pathToEnvFile = path.resolve(cwd, '.env')
 
   // Checks if there is already a DB_HOST env variable
@@ -53,10 +51,10 @@ async function generateEnvFile (cwd = '') {
   // variables not through a file, it still works.
 
   if (!process.env.DB_HOST && !fs.existsSync(pathToEnvFile)) {
-    log(chalk.cyan('Generating .env file...'))
+    log.info('Generating .env file...')
     const secret = generateSecret()
     await writeFileAsync(pathToEnvFile, envTemplate(secret))
-    log(chalk.cyan('Finished generating .env file! Fill it with your own credentials.'))
+    log.info('Finished generating .env file! Fill it with your own credentials.')
 
     return true
   }

--- a/server/utils/logger.js
+++ b/server/utils/logger.js
@@ -1,0 +1,39 @@
+const Logger = require('bunyan')
+const bunyanFormat = require('bunyan-format')
+
+function toBunyanLogLevel (level) {
+  switch (level) {
+    case 'info':
+    case 'trace':
+    case 'debug':
+    case 'warn':
+    case 'error':
+    case 'fatal':
+    case undefined:
+      return level
+    default:
+      throw new Error('Invalid log level')
+  }
+}
+
+function toBunyanFormat (format) {
+  switch (format) {
+    case 'short':
+    case 'long':
+    case 'simple':
+    case 'json':
+    case 'bunyan':
+    case undefined:
+      return format
+    default:
+      throw new Error('Invalid log format')
+  }
+}
+
+const logger = new Logger({
+  level: toBunyanLogLevel(process.env.LOG_LEVEL || 'info'),
+  name: 'flintcms',
+  stream: new bunyanFormat({ outputMode: toBunyanFormat(process.env.LOG_FORMAT || 'short') }) // eslint-disable-line
+})
+
+module.exports = logger

--- a/server/utils/register-plugins.js
+++ b/server/utils/register-plugins.js
@@ -1,8 +1,6 @@
 const mongoose = require('mongoose')
-const chalk = require('chalk')
 const { promisify } = require('util')
 const fs = require('fs')
-const log = require('debug')('flint:plugin')
 
 const readFileAsync = promisify(fs.readFile)
 
@@ -10,7 +8,7 @@ const readFileAsync = promisify(fs.readFile)
  * Registers all plugins by looping over the plugin directory,
  * adding new ones to the DB and registering them with Mongoose
  */
-function registerPlugins () {
+function registerPlugins (log) {
   const plugins = global.FLINT.plugins
   const Plugin = mongoose.model('Plugin')
 
@@ -42,14 +40,14 @@ function registerPlugins () {
       // Update the existing plugin in case its configuration (icon, name, etc) have changed.
       const updatedPlugin = Object.assign(foundPlugin, pluginData, { uid: PluginClass.uid })
       const savedPlugin = await updatedPlugin.save()
-      if (!savedPlugin) log(chalk.red(`Could not save the [${PluginClass.name}] plugin to the database.`))
+      if (!savedPlugin) log.error(`Could not save the [${PluginClass.name}] plugin to the database.`)
     } else {
       // Create a new plugin instance by including the Class model
       // The PluginSchema has { strict: false } so additions to the
       // model will work fine.
       const newPlugin = new Plugin(pluginData)
       const savedPlugin = await newPlugin.save()
-      if (!savedPlugin) log(chalk.red(`Could not save the [${PluginClass.name}] plugin to the database.`))
+      if (!savedPlugin) log.error(`Could not save the [${PluginClass.name}] plugin to the database.`)
     }
   }))
 }

--- a/server/utils/validate-env-variables.js
+++ b/server/utils/validate-env-variables.js
@@ -1,6 +1,3 @@
-const chalk = require('chalk')
-const log = require('debug')('flint')
-
 const variables = [
   'DB_HOST',
   'SESSION_SECRET'
@@ -11,10 +8,10 @@ const variables = [
  * @param {String[]} vars - process.env variables to check for
  * @returns {String[]} - Array of keys that *are not* defined in process.env
  */
-function validateEnvVariables (vars = variables) {
+function validateEnvVariables (vars = variables, log) {
   const missingEnvVariables = vars.filter(v => process.env[v] === undefined || process.env[v] === '')
 
-  missingEnvVariables.forEach(v => log(chalk.red(`Missing the ${v} variable in your .env file!`)))
+  missingEnvVariables.forEach(v => log.error(`Missing the ${v} variable in your .env file!`))
   return missingEnvVariables
 }
 

--- a/test/server/utils/generate-env-file.test.js
+++ b/test/server/utils/generate-env-file.test.js
@@ -22,21 +22,28 @@ describe('generateSecret', () => {
 
 describe('generateEnvFile', () => {
   const oldHost = process.env.DB_HOST
+  let logger
 
   beforeAll(async () => {
     const pathToEnv = path.join(__dirname, '..', '..', 'fixtures', '.env')
     fs.unlink(pathToEnv, f => f)
   })
 
+  beforeEach(() => {
+    logger = {
+      info: jest.fn()
+    }
+  })
+
   it('should not generate a new .env file without DB_HOST', async () => {
     process.env.DB_HOST = 'example'
-    const generatedFile = await generateEnvFile()
+    const generatedFile = await generateEnvFile('', logger)
     return expect(generatedFile).toBe(false)
   })
 
   it('should generate a new .env file', async () => {
     delete process.env.DB_HOST
-    const generatedFile = await generateEnvFile(path.join(__dirname, '..', '..', 'fixtures'))
+    const generatedFile = await generateEnvFile(path.join(__dirname, '..', '..', 'fixtures'), logger)
     return expect(generatedFile).toBe(true)
   })
 

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,1 +1,2 @@
 process.env.DEBUG = 'none'
+process.env.LOG_LEVEL = 'fatal'


### PR DESCRIPTION
Changes the internal logger to use Bunyan instead of `debug`. This is mainly to improve the logs that are shown by default when the server starts, since `debug` requires `DEBUG=flintcms` to be set which just complicates the startup process for most people.