### PR TITLE
Fix pages not updating field layout

### DIFF
--- a/app/actions/pageActions.js
+++ b/app/actions/pageActions.js
@@ -75,6 +75,7 @@ const updateQuery = `mutation ($_id: ID!, $data: PagesInput!) {
     handle
     route
     homepage
+    fieldLayout
     fields {
       fieldId
       handle

--- a/app/components/DatePicker/index.js
+++ b/app/components/DatePicker/index.js
@@ -45,8 +45,7 @@ export default class DatePicker extends Component {
 
   constructor (props) {
     super(props)
-    const { value } = props
-    this.value = value
+    this.value = props.defaultValue ? new Date(props.defaultValue).getTime() : props.value
     const { month, year } = seperateDateObj()
 
     this.selectDate = this.selectDate.bind(this)
@@ -61,7 +60,7 @@ export default class DatePicker extends Component {
       open: false,
       month,
       year,
-      value
+      value: this.value
     }
   }
 

--- a/app/components/Input/index.js
+++ b/app/components/Input/index.js
@@ -110,7 +110,7 @@ export default class Input extends Component {
         value={value}
         onKeyPress={onKeyPress}
         onChange={event => this.handleChange(event)}
-        autoCorrect={autoCorrect}
+        autoCorrect={autoCorrect ? 'true' : 'false'}
         maxLength={maxLength}
       />
     )

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "async/await"
   ],
   "scripts": {
-    "start": "cross-env DEBUG=flint* nodemon --ignore app dev.js",
+    "start": "nodemon --ignore app dev.js",
     "lint": "eslint .",
     "test": "jest --runInBand --coverage && npm run lint",
     "test:update": "jest --runInBand -u",


### PR DESCRIPTION
Fixes an issue where updating a page's `fieldLayout` wouldn't update the Page's content page until a refresh. The update query didn't include the `fieldLayout`, so it wasn't properly merging in to dynamically update it.

Also fixes #66, properly using the provided `defaultValue` to use in the DatePicker component.

Closes #65 
Closes #66 