### PR TITLE
Fix startup

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ module.exports = class Flint {
    * @param {Number} [port] - Defaults to either the process.env port or 4000
    */
   async startServer (port = this.port) {
-    const missingEnvVariables = validateEnvVariables()
+    const missingEnvVariables = validateEnvVariables({ log: logger })
     const didGenerateEnv = await generateEnvFile()
     if (didGenerateEnv && !testing) return process.exit()
 

--- a/server/utils/validate-env-variables.js
+++ b/server/utils/validate-env-variables.js
@@ -8,7 +8,7 @@ const variables = [
  * @param {String[]} vars - process.env variables to check for
  * @returns {String[]} - Array of keys that *are not* defined in process.env
  */
-function validateEnvVariables (vars = variables, log) {
+function validateEnvVariables ({ vars = variables, log }) {
   const missingEnvVariables = vars.filter(v => process.env[v] === undefined || process.env[v] === '')
 
   missingEnvVariables.forEach(v => log.error(`Missing the ${v} variable in your .env file!`))


### PR DESCRIPTION
No logger was being passed to the `validateEnvVariables` function used at startup.

Closes #76 